### PR TITLE
CentOS - SELinux dependency handling

### DIFF
--- a/centos/tasks/main.yml
+++ b/centos/tasks/main.yml
@@ -6,6 +6,12 @@
   yum:
     name: libsemanage-python
     state: latest
+  when: (ansible_distribution_major_version is version('7', '='))
+- name: Install required dependency python3-policycoreutils
+  dnf:
+    name: python3-policycoreutils
+    state: latest
+  when: (ansible_distribution_major_version is version('7', '>'))
 - name: Install bind (named)
   yum:
     name: bind


### PR DESCRIPTION
Followup to this PR:
https://github.com/hack13/ansible-opennic-setup/pull/1

This should handle SELinux dependency properly depending on CentOS version -- assumes the use of Python3